### PR TITLE
BUGFIX: Check that the MenuSet gridfield exists before filtering

### DIFF
--- a/code/MenuAdminExtension.php
+++ b/code/MenuAdminExtension.php
@@ -12,12 +12,15 @@ class MenuAdminExtension extends Extension
     {
         $gridField = $form->Fields()->fieldByName('MenuSet');
 
-        $list = $gridField->getList();
-        $filteredList = $list->filter(array(
-            'SubsiteID' => Subsite::currentSubsiteID()
-        ));
+        if($gridField) {
+            $list = $gridField->getList();
+            $filteredList = $list->filter(array(
+                'SubsiteID' => Subsite::currentSubsiteID()
+            ));
 
-        $gridField->setList($filteredList);
+            $gridField->setList($filteredList);
+        }
+
     }
 
 }


### PR DESCRIPTION
Hi @guttmann! 

I get this error when loading the menumanager on a new subsite:
`Fatal error: Call to a member function getList() on null in MenuAdminExtension.php on line 15`

The issue seems to be that MenuItem is open by default on this installation, so the MenuSet gridfield is not present on the initial load.

To account for this, I've updated the MenuAdminExtension to only apply its logic when the MenuSet gridfield exists