### PR TITLE
Update to support new extensibility for finding Menus

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -12,3 +12,6 @@ Heyday\MenuManager\MenuAdmin:
   extensions:
     - SilverStripe\Subsites\Extensions\SubsiteMenuExtension
     - Guttmann\SilverStripe\MenuAdminExtension
+Heyday\MenuManager\MenuManagerTemplateProvider:
+  extensions:
+    - Guttmann\SilverStripe\MenuManagerTemplateProviderExtension

--- a/src/MenuManagerTemplateProviderExtension.php
+++ b/src/MenuManagerTemplateProviderExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Guttmann\SilverStripe;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\DataList;
+use SilverStripe\Subsites\State\SubsiteState;
+
+class MenuManagerTemplateProviderExtension extends Extension
+{
+    /**
+     * Update MenuSet finding code to account for active subsite
+     *
+     * @param DataList $possibleMatches
+     * @return void
+     */
+    public function updateFindMenuSetByName(&$possibleMatches)
+    {
+        $subsiteId = SubsiteState::singleton()->getSubsiteId();
+        $possibleMatches = $possibleMatches->filter('SubsiteID', $subsiteId);
+    }
+}


### PR DESCRIPTION
New feature is dependent upon https://github.com/heyday/silverstripe-menumanager/pull/54 but does not interrupt normal operation of existing features otherwise.

With heyday/silverstripe-menumanager:
When creating a menu set, a validation was introduced to ensure that
no menu already existed with that name. However no allowance was
made to consider various other filters such as the currently active
subsite.

This was to combat a bug where duplicates could arise but then could
not be managed in the CMS. This change however unfortuantely broke
the integration with this module on a dev/build, where the
configured default menus were repeated for each subsite, with the
same names.

This does not affect sites that already have the menus configured
and e.g. the existing database is copied for development purposes.
But on a fresh project install without existing data this would
cause dev/build fatal/emergency level errors and prevent the
successful conclusion of the script (lots of assumed default data
could be missing). This commit removes this development annoyance.